### PR TITLE
Customized output returned by health check endpoint

### DIFF
--- a/src/Common/Health/CustomWriter.cs
+++ b/src/Common/Health/CustomWriter.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Text.Json;
+using System.Text;
+
+namespace HealthChecksPrimer.Common.Health;
+
+public static class HealthReportExtensions
+{
+    /// <summary>
+    /// Converts the health report to a custom json
+    /// </summary>
+    public static string ToCustomJson(this HealthReport healthReport)
+    {
+        var options = new JsonWriterOptions { Indented = true };
+
+        using var memoryStream = new MemoryStream();
+        using (var jsonWriter = new Utf8JsonWriter(memoryStream, options))
+        {
+            jsonWriter.WriteStartObject();
+            jsonWriter.WriteString("status", healthReport.Status.ToString());
+            jsonWriter.WriteStartObject("results");
+
+            foreach (var healthReportEntry in healthReport.Entries)
+            {
+                jsonWriter.WriteStartObject(healthReportEntry.Key);
+                jsonWriter.WriteString("status", healthReportEntry.Value.Status.ToString());
+                jsonWriter.WriteString("description", healthReportEntry.Value.Description);
+                jsonWriter.WriteStartObject("data");
+
+                foreach (var item in healthReportEntry.Value.Data)
+                {
+                    jsonWriter.WritePropertyName(item.Key);
+                    JsonSerializer.Serialize(jsonWriter, item.Value, item.Value?.GetType() ?? typeof(object));
+                }
+
+                jsonWriter.WriteEndObject();
+                jsonWriter.WriteEndObject();
+            }
+            jsonWriter.WriteEndObject();
+            jsonWriter.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(memoryStream.ToArray());
+    }
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -1,5 +1,6 @@
 using HealthChecksPrimer.Common.Health;
 using HealthChecksPrimer.Common.Services;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,6 +13,17 @@ var app = builder.Build();
 
 app.MapGet("/", () => $"Health Check Primer, environment={builder.Environment.EnvironmentName}");
 app.MapPost("/stock/{symbol}", (string symbol, IStockService stockService) => stockService.Process(symbol));
-app.MapHealthChecks("/health");
+
+
+var healthCheckOptions = new HealthCheckOptions
+{
+    ResponseWriter = (context, healthReport) =>
+    {
+        context.Response.ContentType = "application/json; charset=utf-8";
+        return context.Response.WriteAsync(healthReport.ToCustomJson());
+    }
+};
+
+app.MapHealthChecks("/health", healthCheckOptions);
 
 app.Run();


### PR DESCRIPTION
By default the health check endpoint returns simple string result - the overall status of the health checks (i.e. `Healthy`, `Degraded` `Unhealthy`).
However we can customize the output and provide more details